### PR TITLE
fix Draft.insert not being 1-to-1 with table.insert

### DIFF
--- a/src/table/insert.luau
+++ b/src/table/insert.luau
@@ -12,7 +12,11 @@ local function insert<V>(draft: { V }, pos: number | V, value: V?)
 
 	local clone = getClone(draft :: any)
 
-	return table.insert(clone :: any, pos :: any, value)
+	if value == nil then
+		return table.insert(clone :: any, pos :: any)
+	end
+
+	return table.insert(clone :: any, pos :: number, value)
 end
 
 return insert


### PR DESCRIPTION
(based on #5)
(this is my first time doing a PR, so I apologize if I did something wrong)

the line ```table.insert(clone :: any, pos :: any, value)``` resulted in the following:
![3](https://user-images.githubusercontent.com/84782396/232337590-f34ff77f-dafa-4535-bc60-4176098c91b3.PNG)


I've made it so that if the `value` argument is `nil`, then we treat the `Draft.insert` like `table.insert`'s table-and-value argument format.