### PR TITLE
Allow non-draft tables in table functions

### DIFF
--- a/src/table/insert.luau
+++ b/src/table/insert.luau
@@ -8,15 +8,16 @@ local getClone = require(script.Parent.Parent.getClone)
 	Draft-safe replacement for `table.insert`
 ]=]
 local function insert<V>(draft: { V }, pos: number | V, value: V?)
-	assert(isDraft(draft), "Immut.insert can only be used on drafts")
-
-	local clone = getClone(draft :: any)
-
-	if value == nil then
-		return table.insert(clone :: any, pos :: any)
+	local t = draft
+	if isDraft(draft) then
+		t = getClone(draft :: any)
 	end
 
-	return table.insert(clone :: any, pos :: number, value)
+	if value == nil then
+		return table.insert(t :: any, pos :: any)
+	end
+
+	return table.insert(t :: any, pos :: number, value)
 end
 
 return insert

--- a/src/table/remove_.luau
+++ b/src/table/remove_.luau
@@ -8,11 +8,12 @@ local getClone = require(script.Parent.Parent.getClone)
 	Draft-safe replacement for `table.remove`
 ]=]
 local function remove<V>(draft: { V }, number: number?): V?
-	assert(isDraft(draft), "Immut.remove can only be used on drafts")
+	local t = draft
+	if isDraft(draft) then
+		t = getClone(draft :: any)
+	end
 
-	local clone = getClone(draft :: any)
-
-	return table.remove(clone :: any, number)
+	return table.remove(t :: any, number)
 end
 
 return remove


### PR DESCRIPTION
I was unable to use `insert` on a non-draft table:
```lua
draft.array = {}
insert(draft.array, "value")
```
```
ReplicatedStorage.rbxts_include.node_modules.@rbxts.immut.src.table.insert:11: Immut.insert can only be used on drafts
```

I had to use table.insert instead. It would be cleaner if I could use insert for all tables. Same goes for remove. I don't see any downsides to allowing all tables to be passed into the table functions.

Btw, how do I run tests for the repo? Saw `rbx.yml` but not familiar with what that is for.