### PR TITLE
Add more table functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased changes
+
+- Added `makeDraftSafeReadOnly`
+- Added `table.find`
+- Added `table.concat`
+
 ## 0.4.2
 
 - `produce` now allows all values except tables with metatables as a base

--- a/src/makeDraftSafe.luau
+++ b/src/makeDraftSafe.luau
@@ -15,7 +15,7 @@ type Mutator<K, V, Args..., Return...> = (draft: Draft<K, V>, Args...) -> Return
 	make them draft-safe. `makeDraftSafe` is only necessary if the function will 
 	mutate the table. If the unsafe function is only reading from the table
 	(using rawget), consider using [`original`](/api/Immut#original) or 
-	[`current`](/api/Immut#current) instead.
+	[`current`](/api/Immut#current) instead. Otherwise, you can use [`makeDraftSafeReadOnly`](/api/Immut#makeDraftSafeReadonly).
 
 	This is used internally to wrap functions within Luau's table library, and
 	is exposed for your convenience.

--- a/src/makeDraftSafe.spec.luau
+++ b/src/makeDraftSafe.spec.luau
@@ -15,4 +15,16 @@ return function()
 		expect(rawget(draft, "foo")).to.never.be.ok()
 		expect(draft.foo).to.equal("bar")
 	end)
+
+	it("should allow non-drafts in the returned draft-safe function", function()
+		local nonDraft = {}
+
+		local safe = makeDraftSafe(table.insert)
+
+		expect(function()
+			safe(nonDraft, "foo")
+		end).to.never.throw()
+		
+		expect(nonDraft[1]).to.equal("foo")
+	end)
 end

--- a/src/makeDraftSafeReadOnly.luau
+++ b/src/makeDraftSafeReadOnly.luau
@@ -1,0 +1,46 @@
+--!strict
+local constants = require(script.Parent.constants)
+local isDraft = require(script.Parent.isDraft)
+
+local BASE = constants.BASE
+local CLONE = constants.CLONE
+
+type Draft<K, V> = { [K]: V }
+type Mutator<K, V, Args..., Return...> = (draft: Draft<K, V>, Args...) -> Return...
+
+--[=[
+	@within Immut
+	@function makeDraftSafeReadOnly
+	@param fn T
+	@return T
+
+	A wrapper for functions that bypass metatables (like using rawget) that will
+	make them draft-safe. `makeDraftSafeReadonly` should only be used on functions that will 
+	not mutate the table.
+
+	This is used internally to wrap functions within Luau's table library that only perform read operations, and
+	is exposed for your convenience.
+
+	```lua
+	local find = makeDraftSafeReadOnly(table.find)
+	local concat = makeDraftSafeReadOnly(table.concat)
+
+	local nextState = produce(state, function(draft)
+		local value = find(draft.a, 1)
+		print(concat(draft.b, ",")
+	end)
+	```
+]=]
+local function makeDraftSafeReadOnly<K, V, Args..., Return...>(fn: Mutator<K, V, Args..., Return...>): Mutator<K, V, Args..., Return...>
+	return function(draft, ...)
+		local t = draft
+
+		if isDraft(t) then
+			t = rawget(t, CLONE) or rawget(t, BASE)
+		end
+
+		return fn(t, ...)
+	end
+end
+
+return makeDraftSafeReadOnly

--- a/src/makeDraftSafeReadOnly.spec.luau
+++ b/src/makeDraftSafeReadOnly.spec.luau
@@ -1,0 +1,48 @@
+return function()
+	local Draft = require(script.Parent.Draft)
+	local makeDraftSafeReadOnly = require(script.Parent.makeDraftSafeReadOnly)
+	local constants = require(script.Parent.constants)
+
+	it("should return a draft-safe version of the given function", function()
+		local function unsafe(t, k)
+			return rawget(t, k)
+		end
+
+		local safe = makeDraftSafeReadOnly(unsafe)
+
+		local draft = Draft.new({})
+		local foo = {}
+		draft.foo = foo -- new index that the unsafe fn, unsafe(draft, "foo"), would not find
+
+		expect(safe(draft, "foo")).to.equal(foo)
+	end)
+
+	it("should return a function that does not create a clone of the draft", function()
+		-- so that finishDraft returns the original table if the draft was not modified
+
+		local function unsafe(t, k)
+			return rawget(t, k)
+		end
+
+		local safe = makeDraftSafeReadOnly(unsafe)
+
+		local original = { foo = "bar" }
+		local draft = Draft.new(original)
+
+		safe(draft, "foo")
+
+		expect(rawget(draft, constants.CLONE)).to.never.be.ok()
+	end)
+
+	it("should allow non-drafts in the returned draft-safe function", function()
+		local nonDraft = { "foo", "bar" }
+
+		local safe = makeDraftSafeReadOnly(table.find)
+
+		expect(function()
+			safe(nonDraft, "bar")
+		end).to.never.throw()
+		
+		expect(safe(nonDraft, "bar")).to.equal(2)
+	end)
+end

--- a/src/makeDraftSafeReadOnly.spec.luau
+++ b/src/makeDraftSafeReadOnly.spec.luau
@@ -10,11 +10,14 @@ return function()
 
 		local safe = makeDraftSafeReadOnly(unsafe)
 
-		local draft = Draft.new({})
-		local foo = {}
-		draft.foo = foo -- new index that the unsafe fn, unsafe(draft, "foo"), would not find
+		local original = { foo = {} }
+		local draft = Draft.new(original)
+		
+		local bar = {}
+		draft.bar = bar
 
-		expect(safe(draft, "foo")).to.equal(foo)
+		expect(safe(draft, "foo")).to.equal(original.foo)
+		expect(safe(draft, "bar")).to.equal(bar)
 	end)
 
 	it("should return a function that does not create a clone of the draft", function()

--- a/src/table.luau
+++ b/src/table.luau
@@ -1,4 +1,5 @@
 local makeDraftSafe = require(script.Parent.makeDraftSafe)
+local makeDraftSafeReadOnly = require(script.Parent.makeDraftSafeReadOnly)
 
 --[=[
 	@class table
@@ -83,9 +84,9 @@ return {
 	remove = makeDraftSafe(table.remove),
 	sort = makeDraftSafe(table.sort),
 	clear = makeDraftSafe(table.clear),
-	find = makeDraftSafe(table.find),
-	concat = makeDraftSafe(table.concat),
-	move = makeDraftSafe(table.move),
+	find = makeDraftSafeReadOnly(table.find),
+	concat = makeDraftSafeReadOnly(table.concat),
+	move = makeDraftSafeReadOnly(table.move),
 
 	-- we cannot preserve the type of table.insert when passing it through
 	-- makeDraftSafe because it is an overloaded function. this workaround
@@ -93,4 +94,5 @@ return {
 	insert = (makeDraftSafe(table.insert) :: any) :: typeof(table.insert),
 
 	makeDraftSafe = makeDraftSafe,
+	makeDraftSafeReadOnly = makeDraftSafeReadOnly,
 }

--- a/src/table.luau
+++ b/src/table.luau
@@ -66,12 +66,26 @@ local makeDraftSafe = require(script.Parent.makeDraftSafe)
 	https://create.roblox.com/docs/reference/engine/libraries/table#concat
 ]=]
 
+--[=[
+	@within table
+	@function move
+	@param src { V }
+	@param a number
+	@param b number
+	@param t number?
+	@param dst { V }?
+	@return { V }
+
+	https://create.roblox.com/docs/reference/engine/libraries/table#move
+]=]
+
 return {
 	remove = makeDraftSafe(table.remove),
 	sort = makeDraftSafe(table.sort),
 	clear = makeDraftSafe(table.clear),
 	find = makeDraftSafe(table.find),
 	concat = makeDraftSafe(table.concat),
+	move = makeDraftSafe(table.move),
 
 	-- we cannot preserve the type of table.insert when passing it through
 	-- makeDraftSafe because it is an overloaded function. this workaround

--- a/src/table.luau
+++ b/src/table.luau
@@ -67,19 +67,6 @@ local makeDraftSafeReadOnly = require(script.Parent.makeDraftSafeReadOnly)
 	https://create.roblox.com/docs/reference/engine/libraries/table#concat
 ]=]
 
---[=[
-	@within table
-	@function move
-	@param src { V }
-	@param a number
-	@param b number
-	@param t number?
-	@param dst { V }?
-	@return { V }
-
-	https://create.roblox.com/docs/reference/engine/libraries/table#move
-]=]
-
 return {
 	remove = makeDraftSafe(table.remove),
 	sort = makeDraftSafe(table.sort),

--- a/src/table.luau
+++ b/src/table.luau
@@ -43,10 +43,22 @@ local makeDraftSafe = require(script.Parent.makeDraftSafe)
 	https://create.roblox.com/docs/reference/engine/libraries/table#clear
 ]=]
 
+--[=[
+	@within table
+	@function find
+	@param haystack { V }
+	@param needle V
+	@param init number?
+	@return V?
+
+	https://create.roblox.com/docs/reference/engine/libraries/table#find
+]=]
+
 return {
 	remove = makeDraftSafe(table.remove),
 	sort = makeDraftSafe(table.sort),
 	clear = makeDraftSafe(table.clear),
+	find = makeDraftSafe(table.find),
 
 	-- we cannot preserve the type of table.insert when passing it through
 	-- makeDraftSafe because it is an overloaded function. this workaround

--- a/src/table.luau
+++ b/src/table.luau
@@ -54,11 +54,24 @@ local makeDraftSafe = require(script.Parent.makeDraftSafe)
 	https://create.roblox.com/docs/reference/engine/libraries/table#find
 ]=]
 
+--[=[
+	@within table
+	@function concat
+	@param t { V }
+	@param sep string?
+	@param i number?
+	@param j number?
+	@return string
+
+	https://create.roblox.com/docs/reference/engine/libraries/table#concat
+]=]
+
 return {
 	remove = makeDraftSafe(table.remove),
 	sort = makeDraftSafe(table.sort),
 	clear = makeDraftSafe(table.clear),
 	find = makeDraftSafe(table.find),
+	concat = makeDraftSafe(table.concat),
 
 	-- we cannot preserve the type of table.insert when passing it through
 	-- makeDraftSafe because it is an overloaded function. this workaround

--- a/src/table.luau
+++ b/src/table.luau
@@ -49,7 +49,7 @@ local makeDraftSafe = require(script.Parent.makeDraftSafe)
 	@param haystack { V }
 	@param needle V
 	@param init number?
-	@return V?
+	@return number?
 
 	https://create.roblox.com/docs/reference/engine/libraries/table#find
 ]=]

--- a/src/table.luau
+++ b/src/table.luau
@@ -86,7 +86,6 @@ return {
 	clear = makeDraftSafe(table.clear),
 	find = makeDraftSafeReadOnly(table.find),
 	concat = makeDraftSafeReadOnly(table.concat),
-	move = makeDraftSafeReadOnly(table.move),
 
 	-- we cannot preserve the type of table.insert when passing it through
 	-- makeDraftSafe because it is an overloaded function. this workaround


### PR DESCRIPTION
Added draft-safe table functions that are emitted by roblox-ts (e.g. `array.join(",")` emits `table.concat(array, ",")`